### PR TITLE
erfan

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following methods can be used and are located in the `src/FormAdapter` direc
 To install the package, use composer:
 
 ```sh
-composer require erfan/laravel-collective-spatie-html-parser
+composer require eru/laravel-collective-spatie-html-parser
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "erfan/laravel-collective-spatie-html-parser",
+    "name": "eru/laravel-collective-spatie-html-parser",
     "description": "Adapter class that allows use spatie/laravel-html for old projects that were using the abanondated laravelcollective/html package, and allow to update to new versions of laravel",
     "type": "library",
     "require": {
@@ -10,23 +10,23 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "erfan\\LaravelCollectiveSpatieHtmlParser\\": "src/"
+            "eru\\LaravelCollectiveSpatieHtmlParser\\": "src/"
         }
     },
     "extra": {
         "laravel": {
             "providers": [
-                "erfan\\LaravelCollectiveSpatieHtmlParser\\ServiceProvider"
+                "eru\\LaravelCollectiveSpatieHtmlParser\\ServiceProvider"
             ],
             "aliases": {
-                "Form": "erfan\\LaravelCollectiveSpatieHtmlParser\\FormFacade"
+                "Form": "eru\\LaravelCollectiveSpatieHtmlParser\\FormFacade"
             }
         }
     },
     "authors": [
         {
             "name": "Christian Albán",
-            "email": "christianerfanctdb1d@gmail.com"
+            "email": "christianeructdb1d@gmail.com"
         }
     ],
 

--- a/src/FormAdapter.php
+++ b/src/FormAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace erfan\LaravelCollectiveSpatieHtmlParser;
+namespace eru\LaravelCollectiveSpatieHtmlParser;
 
-use erfan\LaravelCollectiveSpatieHtmlParser\Traits\AttributesUtils;
+use eru\LaravelCollectiveSpatieHtmlParser\Traits\AttributesUtils;
 
 class FormAdapter
 {

--- a/src/FormFacade.php
+++ b/src/FormFacade.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace erfan\LaravelCollectiveSpatieHtmlParser;
+namespace eru\LaravelCollectiveSpatieHtmlParser;
 
 use Illuminate\Support\Facades\Facade;
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace erfan\LaravelCollectiveSpatieHtmlParser;
+namespace eru\LaravelCollectiveSpatieHtmlParser;
 
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 

--- a/src/Traits/AttributesUtils.php
+++ b/src/Traits/AttributesUtils.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace erfan\LaravelCollectiveSpatieHtmlParser\Traits;
+namespace eru\LaravelCollectiveSpatieHtmlParser\Traits;
 
 trait AttributesUtils
 {


### PR DESCRIPTION
Renames package from `erfan` to `eru`

Updates the package namespace and references from the previous author/vendor name `erfan` to the new `eru` namespace. This change ensures consistency and proper identification of the package under the new ownership.